### PR TITLE
全文検索結果をハイライトする

### DIFF
--- a/app/_components/content.tsx
+++ b/app/_components/content.tsx
@@ -5,6 +5,8 @@ import { Syllabus } from "@/app/syllabus";
 import z from "zod";
 import { useFuse } from "../_hooks/use_fuse";
 import { useState } from "react";
+//@ts-ignore
+import Highlighter from "react-highlight-words";
 
 export type Props = {
   syllabus: z.infer<typeof Syllabus>
@@ -17,7 +19,7 @@ export function Content({ syllabus }: Props) {
   };
 
   const { search } = useFuse(syllabus.subjects,
-    { keys: ["summary", "name", "cources", "goal"], threshold: 0.1, ignoreLocation: true });
+    { keys: ["summary", "name", "cources", "goal"], threshold: 0.1, ignoreLocation: true, includeMatches: true });
   const searchResult = search(word);
 
   return (
@@ -32,10 +34,24 @@ export function Content({ syllabus }: Props) {
       <ul className="flex flex-col gap-6">
         {searchResult.map((entry) => {
           const subject = entry.item;
+          const matches = entry.matches ?? [];
+
           return (
             <li key={`${subject.category}_${subject.name}`}>
               <h1 className="font-bold text-2xl">{subject.name}</h1>
-              <p>{subject.summary}</p>
+              <p>
+                {
+                  /* Fuse can generate multiple same match objects, so we should use index as key. */
+                  matches.map((match, i) => (
+                    <Highlighter
+                      key={i}
+                      highlightStyle={{ backgroundColor: "darkslateblue", color: "white" }}
+                      textToHighlight={match.value}
+                      searchWords={[]}
+                      findChunks={() => match.indices.map(range => ({ start: range[0], end: range[1] + 1 }))} />
+                  ))
+                }
+              </p>
             </li>
           )
         })

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"next-themes": "0.4.6",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
+		"react-highlight-words": "^0.21.0",
 		"zod": "^4.1.11"
 	},
 	"devDependencies": {


### PR DESCRIPTION
fix #3

<img width="1161" height="731" alt="image" src="https://github.com/user-attachments/assets/80c75e2f-1300-447d-ac6e-24e6f5546e1c" />
