### PR TITLE
検索条件を URL で状態管理できるようにする

### DIFF
--- a/app/_components/content.tsx
+++ b/app/_components/content.tsx
@@ -4,23 +4,23 @@ import { Input } from "@heroui/input";
 import { Syllabus } from "@/app/syllabus";
 import z from "zod";
 import { useFuse } from "../_hooks/use_fuse";
-import { useState } from "react";
 //@ts-ignore
 import Highlighter from "react-highlight-words";
+import { useQueryState } from "nuqs";
 
 export type Props = {
   syllabus: z.infer<typeof Syllabus>
 };
 
 export function Content({ syllabus }: Props) {
-  const [word, setWord] = useState("");
+  const [word, setWord] = useQueryState("word");
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setWord(event.target.value);
   };
 
   const { search } = useFuse(syllabus.subjects,
     { keys: ["summary", "name", "cources", "goal"], threshold: 0.1, ignoreLocation: true, includeMatches: true });
-  const searchResult = search(word);
+  const searchResult = search(word ?? "");
 
   return (
     <div className="p-8 flex flex-col gap-6">
@@ -28,6 +28,7 @@ export function Content({ syllabus }: Props) {
         <Input
           placeholder="例: 光エレクトロニクス"
           label="検索ワード"
+          value={word ?? ""}
           onChange={handleSearchChange}
         />
       </section>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,12 @@
 import "@/styles/globals.css";
-import { Metadata, Viewport } from "next";
-import { Link } from "@heroui/link";
 import clsx from "clsx";
+import { Metadata, Viewport } from "next";
 
 import { Providers } from "./providers";
 
-import { siteConfig } from "@/config/site";
 import { fontSans } from "@/config/fonts";
+import { siteConfig } from "@/config/site";
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
 export const metadata: Metadata = {
   title: {
@@ -31,6 +31,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+
   return (
     <html suppressHydrationWarning lang="en">
       <head />
@@ -41,9 +42,11 @@ export default function RootLayout({
         )}
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
+          <NuqsAdapter>
             <main>
               {children}
             </main>
+          </NuqsAdapter>
         </Providers>
       </body>
     </html>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"intl-messageformat": "10.7.16",
 		"next": "15.3.1",
 		"next-themes": "0.4.6",
+		"nuqs": "^2.6.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-highlight-words": "^0.21.0",


### PR DESCRIPTION
fix #1 

<img width="1017" height="625" alt="image" src="https://github.com/user-attachments/assets/92b31eb9-2b8a-44cd-b21d-e692ee8a05a6" />

## テスト
- [x] 検索ワードを入力すると URL が変化し、適切に検索できること
- [x] Webページをリロードしたあと、 URL をもとに検索ワードの入力状態が復元されること
- [x] クエリがない状態では、検索条件が空として取り扱われること 