### PR TITLE
非マッチ部分の文字色を薄くする

### DIFF
--- a/app/_components/content.tsx
+++ b/app/_components/content.tsx
@@ -39,7 +39,7 @@ export function Content({ syllabus }: Props) {
           return (
             <li key={`${subject.category}_${subject.name}`}>
               <h1 className="font-bold text-2xl">{subject.name}</h1>
-              <p>
+              <p className="text-gray-400">
                 {
                   /* Fuse can generate multiple same match objects, so we should use index as key. */
                   matches.map((match, i) => (


### PR DESCRIPTION
fix #8 

<img width="996" height="162" alt="image" src="https://github.com/user-attachments/assets/b5e3c365-f1d3-4b59-8d19-4362f91560b1" />
